### PR TITLE
Implement patterns using ableC syntax

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -47,7 +47,8 @@ melt.trynode('silver-ableC') {
       "ableC-string",
       "ableC-constructor",
       "ableC-algebraic-data-types",
-      "ableC-template-algebraic-data-types"
+      "ableC-template-algebraic-data-types",
+      "ableC-halide",
     ]
     for (ext in ext_dependencies) {
       ablec.checkoutExtension(ext)

--- a/grammars/edu.umn.cs.melt.exts.silver.ableC/abstractsyntax/AbstractSyntax.sv
+++ b/grammars/edu.umn.cs.melt.exts.silver.ableC/abstractsyntax/AbstractSyntax.sv
@@ -4,6 +4,7 @@ grammar edu:umn:cs:melt:exts:silver:ableC:abstractsyntax;
 imports silver:langutil:pp;
 
 imports silver:definition:core;
+imports silver:extension:patternmatching;
 
 imports edu:umn:cs:melt:ableC:abstractsyntax:host as ableC;
 
@@ -50,6 +51,48 @@ top::Expr ::= ast::ableC:Expr
   forwards to translate(top.location, reflect(new(ast)));
 }
 
+abstract production ableCDeclsPattern
+top::Pattern ::= ast::ableC:Decls
+{
+  top.unparse = s"ableC_Decls {${sconcat(explode("\n", show(80, ppImplode(line(), ast.pps))))}}";
+  forwards to translatePattern(top.location, reflect(new(ast)));
+}
+
+abstract production ableCDeclPattern
+top::Pattern ::= ast::ableC:Decl
+{
+  top.unparse = s"ableC_Decl {${sconcat(explode("\n", show(80, ast.pp)))}}";
+  forwards to translatePattern(top.location, reflect(new(ast)));
+}
+
+abstract production ableCParametersPattern
+top::Pattern ::= ast::ableC:Parameters
+{
+  top.unparse = s"ableC_Parameters {${sconcat(explode("\n", show(80, ppImplode(pp", ", ast.pps))))}}";
+  forwards to translatePattern(top.location, reflect(new(ast)));
+}
+
+abstract production ableCBaseTypeExprPattern
+top::Pattern ::= ast::ableC:BaseTypeExpr
+{
+  top.unparse = s"ableC_BaseTypeExpr {${sconcat(explode("\n", show(80, ast.pp)))}}";
+  forwards to translatePattern(top.location, reflect(new(ast)));
+}
+
+abstract production ableCStmtPattern
+top::Pattern ::= ast::ableC:Stmt
+{
+  top.unparse = s"ableC_Stmt {${sconcat(explode("\n", show(80, ast.pp)))}}";
+  forwards to translatePattern(top.location, reflect(new(ast)));
+}
+
+abstract production ableCExprPattern
+top::Pattern ::= ast::ableC:Expr
+{
+  top.unparse = s"ableC_Expr {${sconcat(explode("\n", show(80, ast.pp)))}}";
+  forwards to translatePattern(top.location, reflect(new(ast)));
+}
+
 -- AbleC-to-Silver bridge productions
 abstract production escapeDecls
 top::ableC:Decl ::= e::Expr
@@ -72,6 +115,20 @@ top::ableC:Stmt ::= e::Expr
   forwards to ableC:warnStmt([]);
 }
 
+abstract production varStmt
+top::ableC:Stmt ::= n::String
+{
+  top.pp = pp"$$Stmt ${text(n)}";
+  forwards to ableC:warnStmt([]);
+}
+
+abstract production wildStmt
+top::ableC:Stmt ::=
+{
+  top.pp = pp"$$Stmt _";
+  forwards to ableC:warnStmt([]);
+}
+
 abstract production escapeInitializer
 top::ableC:Initializer ::= e::Expr
 {
@@ -90,6 +147,20 @@ abstract production escapeExpr
 top::ableC:Expr ::= e::Expr
 {
   top.pp = pp"$$Expr{${text(e.unparse)}}";
+  forwards to ableC:errorExpr([], location=builtin);
+}
+
+abstract production varExpr
+top::ableC:Expr ::= n::String
+{
+  top.pp = pp"$$Expr ${text(n)}";
+  forwards to ableC:errorExpr([], location=builtin);
+}
+
+abstract production wildExpr
+top::ableC:Expr ::=
+{
+  top.pp = pp"$$Expr _";
   forwards to ableC:errorExpr([], location=builtin);
 }
 
@@ -191,6 +262,20 @@ abstract production escapeBaseTypeExpr
 top::ableC:BaseTypeExpr ::= e::Expr
 {
   top.pp = pp"$$BaseTypeExpr{${text(e.unparse)}}";
+  forwards to ableC:errorTypeExpr([]);
+}
+
+abstract production varBaseTypeExpr
+top::ableC:BaseTypeExpr ::= n::String
+{
+  top.pp = pp"$$BaseTypeExpr ${text(n)}";
+  forwards to ableC:errorTypeExpr([]);
+}
+
+abstract production wildBaseTypeExpr
+top::ableC:BaseTypeExpr ::=
+{
+  top.pp = pp"$$BaseTypeExpr _";
   forwards to ableC:errorTypeExpr([]);
 }
 

--- a/grammars/edu.umn.cs.melt.exts.silver.ableC/abstractsyntax/AbstractSyntax.sv
+++ b/grammars/edu.umn.cs.melt.exts.silver.ableC/abstractsyntax/AbstractSyntax.sv
@@ -23,6 +23,20 @@ top::Expr ::= ast::ableC:Decl
   forwards to translate(top.location, reflect(new(ast)));
 }
 
+abstract production varDecl
+top::ableC:Decl ::= n::Name
+{
+  top.pp = pp"$$Decl ${text(n.unparse)}";
+  forwards to ableC:warnDecl([]);
+}
+
+abstract production wildDecl
+top::ableC:Decl ::=
+{
+  top.pp = pp"$$Decl _";
+  forwards to ableC:warnDecl([]);
+}
+
 abstract production ableCParametersLiteral
 top::Expr ::= ast::ableC:Parameters
 {
@@ -116,9 +130,9 @@ top::ableC:Stmt ::= e::Expr
 }
 
 abstract production varStmt
-top::ableC:Stmt ::= n::String
+top::ableC:Stmt ::= n::Name
 {
-  top.pp = pp"$$Stmt ${text(n)}";
+  top.pp = pp"$$Stmt ${text(n.unparse)}";
   forwards to ableC:warnStmt([]);
 }
 
@@ -151,9 +165,9 @@ top::ableC:Expr ::= e::Expr
 }
 
 abstract production varExpr
-top::ableC:Expr ::= n::String
+top::ableC:Expr ::= n::Name
 {
-  top.pp = pp"$$Expr ${text(n)}";
+  top.pp = pp"$$Expr ${text(n.unparse)}";
   forwards to ableC:errorExpr([], location=builtin);
 }
 
@@ -185,11 +199,24 @@ top::ableC:Name ::= e::Expr
   forwards to ableC:name("<unknown>", location=builtin);
 }
 
-
 abstract production escapeName
 top::ableC:Name ::= e::Expr
 {
   top.pp = pp"$$Name{${text(e.unparse)}}";
+  forwards to ableC:name("<unknown>", location=builtin);
+}
+
+abstract production varName
+top::ableC:Name ::= n::Name
+{
+  top.pp = pp"$$Name ${text(n.unparse)}";
+  forwards to ableC:name("<unknown>", location=builtin);
+}
+
+abstract production wildName
+top::ableC:Name ::=
+{
+  top.pp = pp"$$Name _";
   forwards to ableC:name("<unknown>", location=builtin);
 }
 
@@ -266,9 +293,9 @@ top::ableC:BaseTypeExpr ::= e::Expr
 }
 
 abstract production varBaseTypeExpr
-top::ableC:BaseTypeExpr ::= n::String
+top::ableC:BaseTypeExpr ::= n::Name
 {
-  top.pp = pp"$$BaseTypeExpr ${text(n)}";
+  top.pp = pp"$$BaseTypeExpr ${text(n.unparse)}";
   forwards to ableC:errorTypeExpr([]);
 }
 

--- a/grammars/edu.umn.cs.melt.exts.silver.ableC/abstractsyntax/Translation.sv
+++ b/grammars/edu.umn.cs.melt.exts.silver.ableC/abstractsyntax/Translation.sv
@@ -70,10 +70,14 @@ top::AST ::= prodName::String children::ASTs annotations::NamedASTs
   
   varPatternProductions <-
     ["edu:umn:cs:melt:exts:silver:ableC:abstractsyntax:varExpr",
+     "edu:umn:cs:melt:exts:silver:ableC:abstractsyntax:varName",
+     "edu:umn:cs:melt:exts:silver:ableC:abstractsyntax:varDecl",
      "edu:umn:cs:melt:exts:silver:ableC:abstractsyntax:varStmt",
      "edu:umn:cs:melt:exts:silver:ableC:abstractsyntax:varBaseTypeExpr"];
   wildPatternProductions <-
     ["edu:umn:cs:melt:exts:silver:ableC:abstractsyntax:wildExpr",
+     "edu:umn:cs:melt:exts:silver:ableC:abstractsyntax:wildName",
+     "edu:umn:cs:melt:exts:silver:ableC:abstractsyntax:wildDecl",
      "edu:umn:cs:melt:exts:silver:ableC:abstractsyntax:wildStmt",
      "edu:umn:cs:melt:exts:silver:ableC:abstractsyntax:wildBaseTypeExpr"];
   

--- a/grammars/edu.umn.cs.melt.exts.silver.ableC/abstractsyntax/Translation.sv
+++ b/grammars/edu.umn.cs.melt.exts.silver.ableC/abstractsyntax/Translation.sv
@@ -68,6 +68,15 @@ top::AST ::= prodName::String children::ASTs annotations::NamedASTs
            "edu:umn:cs:melt:ableC:abstractsyntax:host:consEnumItem",
            "edu:umn:cs:melt:ableC:abstractsyntax:host:appendEnumItemList")))];
   
+  varPatternProductions <-
+    ["edu:umn:cs:melt:exts:silver:ableC:abstractsyntax:varExpr",
+     "edu:umn:cs:melt:exts:silver:ableC:abstractsyntax:varStmt",
+     "edu:umn:cs:melt:exts:silver:ableC:abstractsyntax:varBaseTypeExpr"];
+  wildPatternProductions <-
+    ["edu:umn:cs:melt:exts:silver:ableC:abstractsyntax:wildExpr",
+     "edu:umn:cs:melt:exts:silver:ableC:abstractsyntax:wildStmt",
+     "edu:umn:cs:melt:exts:silver:ableC:abstractsyntax:wildBaseTypeExpr"];
+  
   -- "Indirect" escape productions
   escapeTranslation <-
     if

--- a/grammars/edu.umn.cs.melt.exts.silver.ableC/concretesyntax/ConcreteSyntax.sv
+++ b/grammars/edu.umn.cs.melt.exts.silver.ableC/concretesyntax/ConcreteSyntax.sv
@@ -3,6 +3,7 @@ grammar edu:umn:cs:melt:exts:silver:ableC:concretesyntax;
 --imports silver:langutil;
 
 imports silver:definition:core;
+imports silver:extension:patternmatching;
 imports edu:umn:cs:melt:exts:silver:ableC:abstractsyntax;
 imports edu:umn:cs:melt:ableC:abstractsyntax:construction;
 
@@ -31,15 +32,40 @@ concrete productions top::Expr
 | 'ableC_Expr' InAbleC edu:umn:cs:melt:ableC:concretesyntax:LCurly_t ProtoTypedef_c cst::Expr_c edu:umn:cs:melt:ableC:concretesyntax:RCurly_t NotInAbleC
   { forwards to ableCExprLiteral(cst.ast, location=top.location); }
 
+concrete productions top::Pattern
+| 'ableC_Decls' InAbleC edu:umn:cs:melt:ableC:concretesyntax:LCurly_t cst::TranslationUnit_c edu:umn:cs:melt:ableC:concretesyntax:RCurly_t NotInAbleC
+  { forwards to ableCDeclsPattern(foldDecl(cst.ast), location=top.location); }
+| 'ableC_Decl' InAbleC edu:umn:cs:melt:ableC:concretesyntax:LCurly_t cst::ExternalDeclaration_c edu:umn:cs:melt:ableC:concretesyntax:RCurly_t NotInAbleC
+  { forwards to ableCDeclPattern(cst.ast, location=top.location); }
+| 'ableC_Decl' InAbleC edu:umn:cs:melt:ableC:concretesyntax:LCurly_t ProtoTypedef_c cst::ExternalDeclaration_c edu:umn:cs:melt:ableC:concretesyntax:RCurly_t NotInAbleC
+  { forwards to ableCDeclPattern(cst.ast, location=top.location); }
+| 'ableC_Parameters' InAbleC edu:umn:cs:melt:ableC:concretesyntax:LCurly_t cst::ParameterList_c edu:umn:cs:melt:ableC:concretesyntax:RCurly_t NotInAbleC
+  { forwards to ableCParametersPattern(foldParameterDecl(cst.ast), location=top.location); }
+| 'ableC_BaseTypeExpr' InAbleC edu:umn:cs:melt:ableC:concretesyntax:LCurly_t cst::DeclarationSpecifiers_c edu:umn:cs:melt:ableC:concretesyntax:RCurly_t NotInAbleC
+  {
+    cst.givenQualifiers = cst.typeQualifiers;
+    forwards to ableCBaseTypeExprPattern(figureOutTypeFromSpecifiers(cst.location, cst.typeQualifiers, cst.preTypeSpecifiers, cst.realTypeSpecifiers, cst.mutateTypeSpecifiers), location=top.location);
+  }
+| 'ableC_Stmt' InAbleC edu:umn:cs:melt:ableC:concretesyntax:LCurly_t cst::BlockItemList_c edu:umn:cs:melt:ableC:concretesyntax:RCurly_t NotInAbleC
+  { forwards to ableCStmtPattern(foldStmt(cst.ast), location=top.location); }
+| 'ableC_Expr' InAbleC edu:umn:cs:melt:ableC:concretesyntax:LCurly_t cst::Expr_c edu:umn:cs:melt:ableC:concretesyntax:RCurly_t NotInAbleC
+  { forwards to ableCExprPattern(cst.ast, location=top.location); }
+| 'ableC_Expr' InAbleC edu:umn:cs:melt:ableC:concretesyntax:LCurly_t ProtoTypedef_c cst::Expr_c edu:umn:cs:melt:ableC:concretesyntax:RCurly_t NotInAbleC
+  { forwards to ableCExprPattern(cst.ast, location=top.location); }
+
 -- AbleC-to-Silver bridge productions
 concrete productions top::Declaration_c
 | '$Decls' NotInAbleC silver:definition:core:LCurly_t e::Expr silver:definition:core:RCurly_t InAbleC
   { top.ast = escapeDecls(e); }
 | '$Decl' NotInAbleC silver:definition:core:LCurly_t e::Expr silver:definition:core:RCurly_t InAbleC
   { top.ast = escapeDecl(e); }
-concrete productions top::BlockItem_c
+concrete productions top::Stmt_c
 | '$Stmt' NotInAbleC silver:definition:core:LCurly_t e::Expr silver:definition:core:RCurly_t InAbleC
-  { top.ast = [escapeStmt(e)]; }
+  { top.ast = escapeStmt(e); }
+| '$Stmt' n::Identifier_t
+  { top.ast = varStmt(n.lexeme); }
+| '$Stmt' '_'
+  { top.ast = wildStmt(); }
 concrete productions top::Initializer_c
 | '$Initializer' NotInAbleC silver:definition:core:LCurly_t e::Expr silver:definition:core:RCurly_t InAbleC
   { top.ast = escapeInitializer(e); }
@@ -48,6 +74,10 @@ concrete productions top::PrimaryExpr_c
   { top.ast = escapeExprs(e, location=top.location); }
 | '$Expr' NotInAbleC silver:definition:core:LCurly_t e::Expr silver:definition:core:RCurly_t InAbleC
   { top.ast = escapeExpr(e, location=top.location); }
+| '$Expr' n::Identifier_t
+  { top.ast = varExpr(n.lexeme, location=top.location); }
+| '$Expr' '_'
+  { top.ast = wildExpr(location=top.location); }
 | '$intLiteralExpr' NotInAbleC silver:definition:core:LCurly_t e::Expr silver:definition:core:RCurly_t InAbleC
   { top.ast = escapeIntLiteralExpr(e, location=top.location); }
 | '$stringLiteralExpr' NotInAbleC silver:definition:core:LCurly_t e::Expr silver:definition:core:RCurly_t InAbleC
@@ -92,6 +122,16 @@ concrete productions top::TypeSpecifier_c
   {
     -- TODO: Discarding qualifiers here!
     top.realTypeSpecifiers = [escapeBaseTypeExpr(e)];
+    top.preTypeSpecifiers = [];
+  }
+| '$BaseTypeExpr' n::Identifier_t
+  { -- TODO: Discarding qualifiers here!
+    top.realTypeSpecifiers = [varBaseTypeExpr(n.lexeme)];
+    top.preTypeSpecifiers = [];
+  }
+| '$BaseTypeExpr' '_'
+  { -- TODO: Discarding qualifiers here!
+    top.realTypeSpecifiers = [wildBaseTypeExpr()];
     top.preTypeSpecifiers = [];
   }
 concrete productions top::TypeSpecifier_c

--- a/grammars/edu.umn.cs.melt.exts.silver.ableC/concretesyntax/ConcreteSyntax.sv
+++ b/grammars/edu.umn.cs.melt.exts.silver.ableC/concretesyntax/ConcreteSyntax.sv
@@ -59,11 +59,15 @@ concrete productions top::Declaration_c
   { top.ast = escapeDecls(e); }
 | '$Decl' NotInAbleC silver:definition:core:LCurly_t e::Expr silver:definition:core:RCurly_t InAbleC
   { top.ast = escapeDecl(e); }
+| '$Decl' n::Name
+  { top.ast = varDecl(n); }
+| '$Decl' '_'
+  { top.ast = wildDecl(); }
 concrete productions top::Stmt_c
 | '$Stmt' NotInAbleC silver:definition:core:LCurly_t e::Expr silver:definition:core:RCurly_t InAbleC
   { top.ast = escapeStmt(e); }
-| '$Stmt' n::Identifier_t
-  { top.ast = varStmt(n.lexeme); }
+| '$Stmt' n::Name
+  { top.ast = varStmt(n); }
 | '$Stmt' '_'
   { top.ast = wildStmt(); }
 concrete productions top::Initializer_c
@@ -74,8 +78,8 @@ concrete productions top::PrimaryExpr_c
   { top.ast = escapeExprs(e, location=top.location); }
 | '$Expr' NotInAbleC silver:definition:core:LCurly_t e::Expr silver:definition:core:RCurly_t InAbleC
   { top.ast = escapeExpr(e, location=top.location); }
-| '$Expr' n::Identifier_t
-  { top.ast = varExpr(n.lexeme, location=top.location); }
+| '$Expr' n::Name
+  { top.ast = varExpr(n, location=top.location); }
 | '$Expr' '_'
   { top.ast = wildExpr(location=top.location); }
 | '$intLiteralExpr' NotInAbleC silver:definition:core:LCurly_t e::Expr silver:definition:core:RCurly_t InAbleC
@@ -87,6 +91,10 @@ concrete productions top::Identifier_c
   { top.ast = escapeNames(e, location=top.location); }
 | '$Name' NotInAbleC silver:definition:core:LCurly_t e::Expr silver:definition:core:RCurly_t InAbleC
   { top.ast = escapeName(e, location=top.location); }
+| '$Name' n::Name
+  { top.ast = varName(n, location=top.location); }
+| '$Name' '_'
+  { top.ast = wildName(location=top.location); }
 | '$name' NotInAbleC silver:definition:core:LCurly_t e::Expr silver:definition:core:RCurly_t InAbleC
   { top.ast = escape_name(e, location=top.location); }
 concrete productions top::TypeIdName_c
@@ -124,9 +132,9 @@ concrete productions top::TypeSpecifier_c
     top.realTypeSpecifiers = [escapeBaseTypeExpr(e)];
     top.preTypeSpecifiers = [];
   }
-| '$BaseTypeExpr' n::Identifier_t
+| '$BaseTypeExpr' n::Name
   { -- TODO: Discarding qualifiers here!
-    top.realTypeSpecifiers = [varBaseTypeExpr(n.lexeme)];
+    top.realTypeSpecifiers = [varBaseTypeExpr(n)];
     top.preTypeSpecifiers = [];
   }
 | '$BaseTypeExpr' '_'

--- a/grammars/edu.umn.cs.melt.exts.silver.ableC/concretesyntax/ConcreteSyntax.sv
+++ b/grammars/edu.umn.cs.melt.exts.silver.ableC/concretesyntax/ConcreteSyntax.sv
@@ -59,15 +59,15 @@ concrete productions top::Declaration_c
   { top.ast = escapeDecls(e); }
 | '$Decl' NotInAbleC silver:definition:core:LCurly_t e::Expr silver:definition:core:RCurly_t InAbleC
   { top.ast = escapeDecl(e); }
-| '$Decl' n::Name
-  { top.ast = varDecl(n); }
+| '$Decl' n::Identifier_t
+  { top.ast = varDecl(name(n.lexeme, n.location)); }
 | '$Decl' '_'
   { top.ast = wildDecl(); }
 concrete productions top::Stmt_c
 | '$Stmt' NotInAbleC silver:definition:core:LCurly_t e::Expr silver:definition:core:RCurly_t InAbleC
   { top.ast = escapeStmt(e); }
-| '$Stmt' n::Name
-  { top.ast = varStmt(n); }
+| '$Stmt' n::Identifier_t
+  { top.ast = varStmt(name(n.lexeme, n.location)); }
 | '$Stmt' '_'
   { top.ast = wildStmt(); }
 concrete productions top::Initializer_c
@@ -78,8 +78,8 @@ concrete productions top::PrimaryExpr_c
   { top.ast = escapeExprs(e, location=top.location); }
 | '$Expr' NotInAbleC silver:definition:core:LCurly_t e::Expr silver:definition:core:RCurly_t InAbleC
   { top.ast = escapeExpr(e, location=top.location); }
-| '$Expr' n::Name
-  { top.ast = varExpr(n, location=top.location); }
+| '$Expr' n::Identifier_t
+  { top.ast = varExpr(name(n.lexeme, n.location), location=top.location); }
 | '$Expr' '_'
   { top.ast = wildExpr(location=top.location); }
 | '$intLiteralExpr' NotInAbleC silver:definition:core:LCurly_t e::Expr silver:definition:core:RCurly_t InAbleC
@@ -91,8 +91,8 @@ concrete productions top::Identifier_c
   { top.ast = escapeNames(e, location=top.location); }
 | '$Name' NotInAbleC silver:definition:core:LCurly_t e::Expr silver:definition:core:RCurly_t InAbleC
   { top.ast = escapeName(e, location=top.location); }
-| '$Name' n::Name
-  { top.ast = varName(n, location=top.location); }
+| '$Name' n::Identifier_t
+  { top.ast = varName(name(n.lexeme, n.location), location=top.location); }
 | '$Name' '_'
   { top.ast = wildName(location=top.location); }
 | '$name' NotInAbleC silver:definition:core:LCurly_t e::Expr silver:definition:core:RCurly_t InAbleC
@@ -132,9 +132,9 @@ concrete productions top::TypeSpecifier_c
     top.realTypeSpecifiers = [escapeBaseTypeExpr(e)];
     top.preTypeSpecifiers = [];
   }
-| '$BaseTypeExpr' n::Name
+| '$BaseTypeExpr' n::Identifier_t
   { -- TODO: Discarding qualifiers here!
-    top.realTypeSpecifiers = [varBaseTypeExpr(n)];
+    top.realTypeSpecifiers = [varBaseTypeExpr(name(n.lexeme, n.location))];
     top.preTypeSpecifiers = [];
   }
 | '$BaseTypeExpr' '_'

--- a/grammars/edu.umn.cs.melt.exts.silver.ableC/concretesyntax/Terminals.sv
+++ b/grammars/edu.umn.cs.melt.exts.silver.ableC/concretesyntax/Terminals.sv
@@ -41,6 +41,12 @@ parser attribute inAbleC::Boolean action { inAbleC = false; };
 terminal InAbleC '' action { inAbleC = true; };
 terminal NotInAbleC '' action { inAbleC = false; };
 
+terminal Wild_t '_';
+
+disambiguate Wild_t, Identifier_t {
+  pluck Wild_t;
+}
+
 disambiguate NewLine_t, RegexChar_t, silver:definition:core:WhiteSpace
 {
   pluck if inAbleC then NewLine_t else WhiteSpace;


### PR DESCRIPTION
This allows for convenient pattern matching on ableC ASTs, similarly to how expressions are constructed.  This is demoed by the halide extension.  