### PR TITLE
Add ableC-tensor-algebra to Jenkins downstream

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -131,6 +131,7 @@ melt.trynode('silver-ableC') {
       "ableC-algebraic-data-types", "ableC-template-algebraic-data-types",
       "ableC-unification", "ableC-prolog", "ableC-rewriting",
       "ableC-halide",
+      "ableC-tensor-algebra",
       "ableC-sample-projects",
     ]
 


### PR DESCRIPTION
It seems that we still don't have the tensor algebra extension in the integration testing anywhere. I'm addressing this now because I noticed that the Halide extension was updated over this summer, and ended up breaking the tensor algebra extension. I know this fix won't completely fix that problem, but might at least help.
On that note, since I'm not familiar with Jenkins, is there a way to add the tensor algebra extension so that it gets built when the halide extension is built, to ensure that a change to that extension doesn't break the tensor algebra extension?