### PR TITLE
fix bug for detecting existing links that point to missing files

### DIFF
--- a/support/bin/install-silver-bin
+++ b/support/bin/install-silver-bin
@@ -59,17 +59,13 @@ do
     
     echo "Found $REPO"
 
-    if [ -a ~/bin/$SCRIPT_NAME ]; then
+    if [ -e ~/bin/$SCRIPT_NAME -o -h ~/bin/$SCRIPT_NAME ]; then
+        # -h needed in case the link exists but the targeted file does not
         rm ~/bin/$SCRIPT_NAME
         echo "Removed old(?) ~/bin/$SCRIPT_NAME file."
     fi
 
     ln -s "$("$READLINK" -f "$SCRIPT")" ~/bin/
-
-    if [ ! $? ]; then
-        echo "Install failed!!"
-        exit 3
-    fi
 
     echo "Created ~/bin/$SCRIPT_NAME"
 


### PR DESCRIPTION
This is the same fix to the ``support/bin/install-silver-bin`` that we done in Silver.  It changes the file test for ``-a`` (now deprecated) to use ``-e`` and ``-h``.  This properly handles the case with the link in ``~/bin/`` exists but the file it points to does not.