### PR TITLE
Regularize pattern and expression antiquotation syntax, allowing generalized pattern antiquotation

### DIFF
--- a/grammars/edu.umn.cs.melt.exts.silver.ableC/abstractsyntax/AbstractSyntax.sv
+++ b/grammars/edu.umn.cs.melt.exts.silver.ableC/abstractsyntax/AbstractSyntax.sv
@@ -108,17 +108,10 @@ top::ableC:Decl ::= e::Expr
   forwards to ableC:warnDecl([]);
 }
 
-abstract production varDecl
-top::ableC:Decl ::= n::Name
+abstract production antiquotePatternDecl
+top::ableC:Decl ::= p::Pattern
 {
-  top.pp = pp"$$Decl ${text(n.unparse)}";
-  forwards to ableC:warnDecl([]);
-}
-
-abstract production wildDecl
-top::ableC:Decl ::=
-{
-  top.pp = pp"$$Decl _";
+  top.pp = pp"$$Decl{${text(p.unparse)}}";
   forwards to ableC:warnDecl([]);
 }
 
@@ -129,17 +122,10 @@ top::ableC:Stmt ::= e::Expr
   forwards to ableC:warnStmt([]);
 }
 
-abstract production varStmt
-top::ableC:Stmt ::= n::Name
+abstract production antiquotePatternStmt
+top::ableC:Stmt ::= p::Pattern
 {
-  top.pp = pp"$$Stmt ${text(n.unparse)}";
-  forwards to ableC:warnStmt([]);
-}
-
-abstract production wildStmt
-top::ableC:Stmt ::=
-{
-  top.pp = pp"$$Stmt _";
+  top.pp = pp"$$Stmt{${text(p.unparse)}}";
   forwards to ableC:warnStmt([]);
 }
 
@@ -164,17 +150,10 @@ top::ableC:Expr ::= e::Expr
   forwards to ableC:errorExpr([], location=builtin);
 }
 
-abstract production varExpr
-top::ableC:Expr ::= n::Name
+abstract production antiquotePatternExpr
+top::ableC:Expr ::= p::Pattern
 {
-  top.pp = pp"$$Expr ${text(n.unparse)}";
-  forwards to ableC:errorExpr([], location=builtin);
-}
-
-abstract production wildExpr
-top::ableC:Expr ::=
-{
-  top.pp = pp"$$Expr _";
+  top.pp = pp"$$Expr{${text(p.unparse)}}";
   forwards to ableC:errorExpr([], location=builtin);
 }
 
@@ -206,17 +185,10 @@ top::ableC:Name ::= e::Expr
   forwards to ableC:name("<unknown>", location=builtin);
 }
 
-abstract production varName
-top::ableC:Name ::= n::Name
+abstract production antiquotePatternName
+top::ableC:Name ::= p::Pattern
 {
-  top.pp = pp"$$Name ${text(n.unparse)}";
-  forwards to ableC:name("<unknown>", location=builtin);
-}
-
-abstract production wildName
-top::ableC:Name ::=
-{
-  top.pp = pp"$$Name _";
+  top.pp = pp"$$Name{${text(p.unparse)}}";
   forwards to ableC:name("<unknown>", location=builtin);
 }
 
@@ -292,17 +264,10 @@ top::ableC:BaseTypeExpr ::= e::Expr
   forwards to ableC:errorTypeExpr([]);
 }
 
-abstract production varBaseTypeExpr
-top::ableC:BaseTypeExpr ::= n::Name
+abstract production antiquotePatternBaseTypeExpr
+top::ableC:BaseTypeExpr ::= p::Pattern
 {
-  top.pp = pp"$$BaseTypeExpr ${text(n.unparse)}";
-  forwards to ableC:errorTypeExpr([]);
-}
-
-abstract production wildBaseTypeExpr
-top::ableC:BaseTypeExpr ::=
-{
-  top.pp = pp"$$BaseTypeExpr _";
+  top.pp = pp"$$BaseTypeExpr{${text(p.unparse)}}";
   forwards to ableC:errorTypeExpr([]);
 }
 

--- a/grammars/edu.umn.cs.melt.exts.silver.ableC/abstractsyntax/Translation.sv
+++ b/grammars/edu.umn.cs.melt.exts.silver.ableC/abstractsyntax/Translation.sv
@@ -68,18 +68,12 @@ top::AST ::= prodName::String children::ASTs annotations::NamedASTs
            "edu:umn:cs:melt:ableC:abstractsyntax:host:consEnumItem",
            "edu:umn:cs:melt:ableC:abstractsyntax:host:appendEnumItemList")))];
   
-  varPatternProductions <-
-    ["edu:umn:cs:melt:exts:silver:ableC:abstractsyntax:varExpr",
-     "edu:umn:cs:melt:exts:silver:ableC:abstractsyntax:varName",
-     "edu:umn:cs:melt:exts:silver:ableC:abstractsyntax:varDecl",
-     "edu:umn:cs:melt:exts:silver:ableC:abstractsyntax:varStmt",
-     "edu:umn:cs:melt:exts:silver:ableC:abstractsyntax:varBaseTypeExpr"];
-  wildPatternProductions <-
-    ["edu:umn:cs:melt:exts:silver:ableC:abstractsyntax:wildExpr",
-     "edu:umn:cs:melt:exts:silver:ableC:abstractsyntax:wildName",
-     "edu:umn:cs:melt:exts:silver:ableC:abstractsyntax:wildDecl",
-     "edu:umn:cs:melt:exts:silver:ableC:abstractsyntax:wildStmt",
-     "edu:umn:cs:melt:exts:silver:ableC:abstractsyntax:wildBaseTypeExpr"];
+  patternAntiquoteProductions <-
+    ["edu:umn:cs:melt:exts:silver:ableC:abstractsyntax:antiquotePatternExpr",
+     "edu:umn:cs:melt:exts:silver:ableC:abstractsyntax:antiquotePatternName",
+     "edu:umn:cs:melt:exts:silver:ableC:abstractsyntax:antiquotePatternDecl",
+     "edu:umn:cs:melt:exts:silver:ableC:abstractsyntax:antiquotePatternStmt",
+     "edu:umn:cs:melt:exts:silver:ableC:abstractsyntax:antiquotePatternBaseTypeExpr"];
   
   -- "Indirect" antiquote productions
   antiquoteTranslation <-

--- a/grammars/edu.umn.cs.melt.exts.silver.ableC/concretesyntax/antiquotation/ConcreteSyntax.sv
+++ b/grammars/edu.umn.cs.melt.exts.silver.ableC/concretesyntax/antiquotation/ConcreteSyntax.sv
@@ -1,136 +1,119 @@
 grammar edu:umn:cs:melt:exts:silver:ableC:concretesyntax:antiquotation;
 
 imports silver:definition:core;
+imports silver:extension:patternmatching;
 imports edu:umn:cs:melt:exts:silver:ableC:abstractsyntax;
-imports edu:umn:cs:melt:ableC:concretesyntax;
+imports edu:umn:cs:melt:ableC:concretesyntax hiding LCurly_t, RCurly_t;
 
 -- AbleC-to-Silver bridge productions
 concrete productions top::Declaration_c
-| '$Decls' silver:definition:core:LCurly_t e::Expr silver:definition:core:RCurly_t
+| '$Decls' '{' e::Expr '}'
   layout {silver:definition:core:WhiteSpace, BlockComments, Comments}
   { top.ast = antiquoteDecls(e); }
-| '$Decl' silver:definition:core:LCurly_t e::Expr silver:definition:core:RCurly_t
+| AntiquoteDecl_t '{' e::Expr '}'
   layout {silver:definition:core:WhiteSpace, BlockComments, Comments}
   { top.ast = antiquoteDecl(e); }
-| '$Decl' n::IdLower_t
+| AntiquoteDeclPattern_t '{' p::Pattern '}'
   layout {silver:definition:core:WhiteSpace, BlockComments, Comments}
-  { top.ast = varDecl(nameIdLower(n, location=n.location)); }
-| '$Decl' '_'
-  layout {silver:definition:core:WhiteSpace, BlockComments, Comments}
-  { top.ast = wildDecl(); }
+  { top.ast = antiquotePatternDecl(p); }
 concrete productions top::Stmt_c
-| '$Stmt' silver:definition:core:LCurly_t e::Expr silver:definition:core:RCurly_t
+| AntiquoteStmt_t '{' e::Expr '}'
   layout {silver:definition:core:WhiteSpace, BlockComments, Comments}
   { top.ast = antiquoteStmt(e); }
-| '$Stmt' n::IdLower_t
+| AntiquoteStmtPattern_t '{' p::Pattern '}'
   layout {silver:definition:core:WhiteSpace, BlockComments, Comments}
-  { top.ast = varStmt(nameIdLower(n, location=n.location)); }
-| '$Stmt' '_'
-  layout {silver:definition:core:WhiteSpace, BlockComments, Comments}
-  { top.ast = wildStmt(); }
+  { top.ast = antiquotePatternStmt(p); }
 concrete productions top::Initializer_c
-| '$Initializer' silver:definition:core:LCurly_t e::Expr silver:definition:core:RCurly_t
+| '$Initializer' '{' e::Expr '}'
   layout {silver:definition:core:WhiteSpace, BlockComments, Comments}
   { top.ast = antiquoteInitializer(e); }
 concrete productions top::PrimaryExpr_c
-| '$Exprs' silver:definition:core:LCurly_t e::Expr silver:definition:core:RCurly_t
+| '$Exprs' '{' e::Expr '}'
   layout {silver:definition:core:WhiteSpace, BlockComments, Comments}
   { top.ast = antiquoteExprs(e, location=top.location); }
-| '$Expr' silver:definition:core:LCurly_t e::Expr silver:definition:core:RCurly_t
+| AntiquoteExpr_t '{' e::Expr '}'
   layout {silver:definition:core:WhiteSpace, BlockComments, Comments}
   { top.ast = antiquoteExpr(e, location=top.location); }
-| '$Expr' n::IdLower_t
+| AntiquoteExprPattern_t '{' p::Pattern '}'
   layout {silver:definition:core:WhiteSpace, BlockComments, Comments}
-  { top.ast = varExpr(nameIdLower(n, location=n.location), location=top.location); }
-| '$Expr' '_'
-  layout {silver:definition:core:WhiteSpace, BlockComments, Comments}
-  { top.ast = wildExpr(location=top.location); }
-| '$intLiteralExpr' silver:definition:core:LCurly_t e::Expr silver:definition:core:RCurly_t
+  { top.ast = antiquotePatternExpr(p, location=top.location); }
+| '$intLiteralExpr' '{' e::Expr '}'
   layout {silver:definition:core:WhiteSpace, BlockComments, Comments}
   { top.ast = antiquoteIntLiteralExpr(e, location=top.location); }
-| '$stringLiteralExpr' silver:definition:core:LCurly_t e::Expr silver:definition:core:RCurly_t
+| '$stringLiteralExpr' '{' e::Expr '}'
   layout {silver:definition:core:WhiteSpace, BlockComments, Comments}
   { top.ast = antiquoteStringLiteralExpr(e, location=top.location); }
 concrete productions top::Identifier_c
-| '$Names' silver:definition:core:LCurly_t e::Expr silver:definition:core:RCurly_t
+| '$Names' '{' e::Expr '}'
   layout {silver:definition:core:WhiteSpace, BlockComments, Comments}
   { top.ast = antiquoteNames(e, location=top.location); }
-| '$Name' silver:definition:core:LCurly_t e::Expr silver:definition:core:RCurly_t
+| AntiquoteName_t '{' e::Expr '}'
   layout {silver:definition:core:WhiteSpace, BlockComments, Comments}
   { top.ast = antiquoteName(e, location=top.location); }
-| '$Name' n::IdLower_t
+| AntiquoteNamePattern_t '{' p::Pattern '}'
   layout {silver:definition:core:WhiteSpace, BlockComments, Comments}
-  { top.ast = varName(nameIdLower(n, location=n.location), location=top.location); }
-| '$Name' '_'
-  layout {silver:definition:core:WhiteSpace, BlockComments, Comments}
-  { top.ast = wildName(location=top.location); }
-| '$name' silver:definition:core:LCurly_t e::Expr silver:definition:core:RCurly_t
+  { top.ast = antiquotePatternName(p, location=top.location); }
+| '$name' '{' e::Expr '}'
   layout {silver:definition:core:WhiteSpace, BlockComments, Comments}
   { top.ast = antiquote_name(e, location=top.location); }
 concrete productions top::TypeIdName_c
-| '$TName' silver:definition:core:LCurly_t e::Expr silver:definition:core:RCurly_t
+| '$TName' '{' e::Expr '}'
   layout {silver:definition:core:WhiteSpace, BlockComments, Comments}
   { top.ast = antiquoteTName(e, location=top.location); }
-| '$tname' silver:definition:core:LCurly_t e::Expr silver:definition:core:RCurly_t
+| '$tname' '{' e::Expr '}'
   layout {silver:definition:core:WhiteSpace, BlockComments, Comments}
   { top.ast = antiquote_tname(e, location=top.location); }
 concrete productions top::StorageClassSpecifier_c
-| '$StorageClasses' silver:definition:core:LCurly_t e::Expr silver:definition:core:RCurly_t
+| '$StorageClasses' '{' e::Expr '}'
   layout {silver:definition:core:WhiteSpace, BlockComments, Comments}
   {
     top.isTypedef = false;
     top.storageClass = [antiquoteStorageClasses(e, top.location)];
   }
 concrete productions top::ParameterDeclaration_c
-| '$Parameters' silver:definition:core:LCurly_t e::Expr silver:definition:core:RCurly_t
+| '$Parameters' '{' e::Expr '}'
   layout {silver:definition:core:WhiteSpace, BlockComments, Comments}
   {
     top.declaredIdents = [];
     top.ast = antiquoteParameters(e, top.location);
   }
 concrete productions top::StructDeclaration_c
-| '$StructItemList' silver:definition:core:LCurly_t e::Expr silver:definition:core:RCurly_t
+| '$StructItemList' '{' e::Expr '}'
   layout {silver:definition:core:WhiteSpace, BlockComments, Comments}
   { top.ast = [antiquoteStructItemList(e, top.location)]; }
 concrete productions top::Enumerator_c
-| '$EnumItemList' silver:definition:core:LCurly_t e::Expr silver:definition:core:RCurly_t
+| '$EnumItemList' '{' e::Expr '}'
   layout {silver:definition:core:WhiteSpace, BlockComments, Comments}
   { top.ast = [antiquoteEnumItemList(e, top.location)]; }
 concrete productions top::TypeName_c
-| '$TypeNames' silver:definition:core:LCurly_t e::Expr silver:definition:core:RCurly_t
+| '$TypeNames' '{' e::Expr '}'
   layout {silver:definition:core:WhiteSpace, BlockComments, Comments}
   { top.ast = antiquoteTypeNames(e); }
-| '$TypeName' silver:definition:core:LCurly_t e::Expr silver:definition:core:RCurly_t
+| '$TypeName' '{' e::Expr '}'
   layout {silver:definition:core:WhiteSpace, BlockComments, Comments}
   { top.ast = antiquoteTypeName(e); }
 concrete productions top::TypeSpecifier_c
-| '$BaseTypeExpr' silver:definition:core:LCurly_t e::Expr silver:definition:core:RCurly_t
+| AntiquoteBaseTypeExpr_t '{' e::Expr '}'
   layout {silver:definition:core:WhiteSpace, BlockComments, Comments}
   {
     -- TODO: Discarding qualifiers here!
     top.realTypeSpecifiers = [antiquoteBaseTypeExpr(e)];
     top.preTypeSpecifiers = [];
   }
-| '$BaseTypeExpr' n::IdLower_t
+| AntiquoteBaseTypeExprPattern_t '{' p::Pattern '}'
   layout {silver:definition:core:WhiteSpace, BlockComments, Comments}
   { -- TODO: Discarding qualifiers here!
-    top.realTypeSpecifiers = [varBaseTypeExpr(nameIdLower(n, location=n.location))];
-    top.preTypeSpecifiers = [];
-  }
-| '$BaseTypeExpr' '_'
-  layout {silver:definition:core:WhiteSpace, BlockComments, Comments}
-  { -- TODO: Discarding qualifiers here!
-    top.realTypeSpecifiers = [wildBaseTypeExpr()];
+    top.realTypeSpecifiers = [antiquotePatternBaseTypeExpr(p)];
     top.preTypeSpecifiers = [];
   }
 concrete productions top::TypeSpecifier_c
-| '$directTypeExpr' silver:definition:core:LCurly_t e::Expr silver:definition:core:RCurly_t
+| '$directTypeExpr' '{' e::Expr '}'
   layout {silver:definition:core:WhiteSpace, BlockComments, Comments}
   {
     top.realTypeSpecifiers = [antiquoteDirectTypeExpr(top.givenQualifiers, e, top.location)];
     top.preTypeSpecifiers = [];
   }
 concrete productions top::Attrib_c
-| '$Attrib' silver:definition:core:LCurly_t e::Expr silver:definition:core:RCurly_t
+| '$Attrib' '{' e::Expr '}'
   layout {silver:definition:core:WhiteSpace, BlockComments, Comments}
   { top.ast = antiquoteAttrib(e); }

--- a/grammars/edu.umn.cs.melt.exts.silver.ableC/concretesyntax/antiquotation/ConcreteSyntax.sv
+++ b/grammars/edu.umn.cs.melt.exts.silver.ableC/concretesyntax/antiquotation/ConcreteSyntax.sv
@@ -3,7 +3,8 @@ grammar edu:umn:cs:melt:exts:silver:ableC:concretesyntax:antiquotation;
 imports silver:definition:core;
 imports silver:extension:patternmatching;
 imports edu:umn:cs:melt:exts:silver:ableC:abstractsyntax;
-imports edu:umn:cs:melt:ableC:concretesyntax hiding LCurly_t, RCurly_t;
+imports edu:umn:cs:melt:ableC:concretesyntax
+  hiding LCurly_t, RCurly_t; -- We only use the ones from Silver, makes '{' terminal syntax unambigous
 
 -- AbleC-to-Silver bridge productions
 concrete productions top::Declaration_c

--- a/grammars/edu.umn.cs.melt.exts.silver.ableC/concretesyntax/antiquotation/Terminals.sv
+++ b/grammars/edu.umn.cs.melt.exts.silver.ableC/concretesyntax/antiquotation/Terminals.sv
@@ -1,34 +1,50 @@
 grammar edu:umn:cs:melt:exts:silver:ableC:concretesyntax:antiquotation;
 
+imports edu:umn:cs:melt:exts:silver:ableC:concretesyntax:quotation;
+
 temp_imp_ide_font font_antiquote color(123, 0, 82) bold italic;
-lexer class Antiquote font=font_antiquote;
+lexer class Antiquote
+  disambiguate {
+    -- Ambiguities between antiquote terminals should consist of 1 expression
+    -- and 1 pattern antiquote terminal.
+    if (inPattern)
+      -- Pick the pattern antiquote terminal
+      pluck head(intersectBy(terminalIdEq, shiftable, PatternAntiquote));
+    else
+      -- Pick the expression antiquote terminal
+      pluck head(intersectBy(terminalIdEq, shiftable, ExprAntiquote));
+  },
+  font=font_antiquote;
 
-marking terminal AntiquoteDecls_t             '$Decls'             lexer classes {Antiquote, Reserved};
-marking terminal AntiquoteDecl_t              '$Decl'              lexer classes {Antiquote, Reserved};
-marking terminal AntiquoteStmt_t              '$Stmt'              lexer classes {Antiquote, Reserved};
-marking terminal AntiquoteInitializer_t       '$Initializer'       lexer classes {Antiquote, Reserved};
-marking terminal AntiquoteExprs_t             '$Exprs'             lexer classes {Antiquote, Reserved};
-marking terminal AntiquoteExpr_t              '$Expr'              lexer classes {Antiquote, Reserved};
-marking terminal AntiquoteIntLiteralExpr_t    '$intLiteralExpr'    lexer classes {Antiquote, Reserved};
-marking terminal AntiquoteStringLiteralExpr_t '$stringLiteralExpr' lexer classes {Antiquote, Reserved};
-marking terminal AntiquoteNames_t             '$Names'             lexer classes {Antiquote, Reserved};
-marking terminal AntiquoteName_t              '$Name'              lexer classes {Antiquote, Reserved};
-marking terminal AntiquoteTName_t             '$TName'             lexer classes {Antiquote, Reserved};
-marking terminal Antiquote_name_t             '$name'              lexer classes {Antiquote, Reserved};
-marking terminal Antiquote_tname_t            '$tname'             lexer classes {Antiquote, Reserved};
-marking terminal AntiquoteStorageClasses      '$StorageClasses'    lexer classes {Antiquote, Reserved};
-marking terminal AntiquoteParameters_t        '$Parameters'        lexer classes {Antiquote, Reserved};
-marking terminal AntiquoteStructItemList_t    '$StructItemList'    lexer classes {Antiquote, Reserved};
-marking terminal AntiquoteEnumItemList_t      '$EnumItemList'      lexer classes {Antiquote, Reserved};
-marking terminal AntiquoteTypeNames_t         '$TypeNames'         lexer classes {Antiquote, Reserved};
-marking terminal AntiquoteTypeName_t          '$TypeName'          lexer classes {Antiquote, Reserved};
-marking terminal AntiquoteBaseTypeExpr_t      '$BaseTypeExpr'      lexer classes {Antiquote, Reserved};
---marking terminal AntiquoteTypeModifierExpr_t  '$TypeModifierExpr'  lexer classes {Antiquote, Reserved};
-marking terminal AntiquoteType_t              '$directTypeExpr'    lexer classes {Antiquote, Reserved};
-marking terminal AntiquoteAttrib_t            '$Attrib'            lexer classes {Antiquote, Reserved}, dominates {AttributeNameUnfetterdByKeywords_t};
+lexer class ExprAntiquote extends Antiquote;
+lexer class PatternAntiquote extends Antiquote;
 
-terminal Wild_t '_';
+marking terminal AntiquoteDecls_t             '$Decls'             lexer classes {ExprAntiquote, Reserved};
+marking terminal AntiquoteDecl_t              '$Decl'              lexer classes {ExprAntiquote, Reserved};
+marking terminal AntiquoteStmt_t              '$Stmt'              lexer classes {ExprAntiquote, Reserved};
+marking terminal AntiquoteInitializer_t       '$Initializer'       lexer classes {ExprAntiquote, Reserved};
+marking terminal AntiquoteExprs_t             '$Exprs'             lexer classes {ExprAntiquote, Reserved};
+marking terminal AntiquoteExpr_t              '$Expr'              lexer classes {ExprAntiquote, Reserved};
+marking terminal AntiquoteIntLiteralExpr_t    '$intLiteralExpr'    lexer classes {ExprAntiquote, Reserved};
+marking terminal AntiquoteStringLiteralExpr_t '$stringLiteralExpr' lexer classes {ExprAntiquote, Reserved};
+marking terminal AntiquoteNames_t             '$Names'             lexer classes {ExprAntiquote, Reserved};
+marking terminal AntiquoteName_t              '$Name'              lexer classes {ExprAntiquote, Reserved};
+marking terminal AntiquoteTName_t             '$TName'             lexer classes {ExprAntiquote, Reserved};
+marking terminal Antiquote_name_t             '$name'              lexer classes {ExprAntiquote, Reserved};
+marking terminal Antiquote_tname_t            '$tname'             lexer classes {ExprAntiquote, Reserved};
+marking terminal AntiquoteStorageClasses      '$StorageClasses'    lexer classes {ExprAntiquote, Reserved};
+marking terminal AntiquoteParameters_t        '$Parameters'        lexer classes {ExprAntiquote, Reserved};
+marking terminal AntiquoteStructItemList_t    '$StructItemList'    lexer classes {ExprAntiquote, Reserved};
+marking terminal AntiquoteEnumItemList_t      '$EnumItemList'      lexer classes {ExprAntiquote, Reserved};
+marking terminal AntiquoteTypeNames_t         '$TypeNames'         lexer classes {ExprAntiquote, Reserved};
+marking terminal AntiquoteTypeName_t          '$TypeName'          lexer classes {ExprAntiquote, Reserved};
+marking terminal AntiquoteBaseTypeExpr_t      '$BaseTypeExpr'      lexer classes {ExprAntiquote, Reserved};
+--marking terminal AntiquoteTypeModifierExpr_t  '$TypeModifierExpr'  lexer classes {ExprAntiquote, Reserved};
+marking terminal AntiquoteType_t              '$directTypeExpr'    lexer classes {ExprAntiquote, Reserved};
+marking terminal AntiquoteAttrib_t            '$Attrib'            lexer classes {ExprAntiquote, Reserved}, dominates {AttributeNameUnfetterdByKeywords_t};
 
-disambiguate Wild_t, Identifier_t {
-  pluck Wild_t;
-}
+marking terminal AntiquoteDeclPattern_t         '$Decl'            lexer classes {PatternAntiquote, Reserved};
+marking terminal AntiquoteStmtPattern_t         '$Stmt'            lexer classes {PatternAntiquote, Reserved};
+marking terminal AntiquoteExprPattern_t         '$Expr'            lexer classes {PatternAntiquote, Reserved};
+marking terminal AntiquoteNamePattern_t         '$Name'            lexer classes {PatternAntiquote, Reserved};
+marking terminal AntiquoteBaseTypeExprPattern_t '$BaseTypeExpr'    lexer classes {PatternAntiquote, Reserved};

--- a/grammars/edu.umn.cs.melt.exts.silver.ableC/concretesyntax/quotation/ConcreteSyntax.sv
+++ b/grammars/edu.umn.cs.melt.exts.silver.ableC/concretesyntax/quotation/ConcreteSyntax.sv
@@ -1,6 +1,6 @@
 grammar edu:umn:cs:melt:exts:silver:ableC:concretesyntax:quotation;
 
-imports silver:definition:core;
+imports silver:definition:core hiding LCurly_t, RCurly_t;
 imports silver:extension:patternmatching;
 imports edu:umn:cs:melt:exts:silver:ableC:abstractsyntax;
 imports edu:umn:cs:melt:ableC:abstractsyntax:construction;
@@ -9,59 +9,67 @@ imports edu:umn:cs:melt:ableC:concretesyntax:construction;
 
 -- Silver-to-ableC bridge productions
 concrete productions top::Expr
-| 'ableC_Decls' edu:umn:cs:melt:ableC:concretesyntax:LCurly_t cst::TranslationUnit_c edu:umn:cs:melt:ableC:concretesyntax:RCurly_t
+| 'ableC_Decls' '{' cst::TranslationUnit_c '}'
   layout {LineComment_t, BlockComment_t, Spaces_t, NewLine_t}
   { forwards to quoteDecls(foldDecl(cst.ast), location=top.location); }
-| 'ableC_Decl' edu:umn:cs:melt:ableC:concretesyntax:LCurly_t cst::ExternalDeclaration_c edu:umn:cs:melt:ableC:concretesyntax:RCurly_t
+| 'ableC_Decl' '{' cst::ExternalDeclaration_c '}'
   layout {LineComment_t, BlockComment_t, Spaces_t, NewLine_t}
   { forwards to quoteDecl(cst.ast, location=top.location); }
-| 'ableC_Decl' edu:umn:cs:melt:ableC:concretesyntax:LCurly_t ProtoTypedef_c cst::ExternalDeclaration_c edu:umn:cs:melt:ableC:concretesyntax:RCurly_t
+| 'ableC_Decl' '{' ProtoTypedef_c cst::ExternalDeclaration_c '}'
   layout {LineComment_t, BlockComment_t, Spaces_t, NewLine_t}
   { forwards to quoteDecl(cst.ast, location=top.location); }
-| 'ableC_Parameters' edu:umn:cs:melt:ableC:concretesyntax:LCurly_t cst::ParameterList_c edu:umn:cs:melt:ableC:concretesyntax:RCurly_t
+| 'ableC_Parameters' '{' cst::ParameterList_c '}'
   layout {LineComment_t, BlockComment_t, Spaces_t, NewLine_t}
   { forwards to quoteParameters(foldParameterDecl(cst.ast), location=top.location); }
-| 'ableC_BaseTypeExpr' edu:umn:cs:melt:ableC:concretesyntax:LCurly_t cst::DeclarationSpecifiers_c edu:umn:cs:melt:ableC:concretesyntax:RCurly_t
+| 'ableC_BaseTypeExpr' '{' cst::DeclarationSpecifiers_c '}'
   layout {LineComment_t, BlockComment_t, Spaces_t, NewLine_t}
   {
     cst.givenQualifiers = cst.typeQualifiers;
     forwards to quoteBaseTypeExpr(figureOutTypeFromSpecifiers(cst.location, cst.typeQualifiers, cst.preTypeSpecifiers, cst.realTypeSpecifiers, cst.mutateTypeSpecifiers), location=top.location);
   }
-| 'ableC_Stmt' edu:umn:cs:melt:ableC:concretesyntax:LCurly_t cst::BlockItemList_c edu:umn:cs:melt:ableC:concretesyntax:RCurly_t
+| 'ableC_Stmt' '{' cst::BlockItemList_c '}'
   layout {LineComment_t, BlockComment_t, Spaces_t, NewLine_t}
   { forwards to quoteStmt(foldStmt(cst.ast), location=top.location); }
-| 'ableC_Expr' edu:umn:cs:melt:ableC:concretesyntax:LCurly_t cst::Expr_c edu:umn:cs:melt:ableC:concretesyntax:RCurly_t
+| 'ableC_Expr' '{' cst::Expr_c '}'
   layout {LineComment_t, BlockComment_t, Spaces_t, NewLine_t}
   { forwards to quoteExpr(cst.ast, location=top.location); }
-| 'ableC_Expr' edu:umn:cs:melt:ableC:concretesyntax:LCurly_t ProtoTypedef_c cst::Expr_c edu:umn:cs:melt:ableC:concretesyntax:RCurly_t
+| 'ableC_Expr' '{' ProtoTypedef_c cst::Expr_c '}'
   layout {LineComment_t, BlockComment_t, Spaces_t, NewLine_t}
   { forwards to quoteExpr(cst.ast, location=top.location); }
 
 concrete productions top::Pattern
-| 'ableC_Decls' edu:umn:cs:melt:ableC:concretesyntax:LCurly_t cst::TranslationUnit_c edu:umn:cs:melt:ableC:concretesyntax:RCurly_t
+| 'ableC_Decls' BeginPattern_t '{' cst::TranslationUnit_c '}'
   layout {LineComment_t, BlockComment_t, Spaces_t, NewLine_t}
   { forwards to quoteDeclsPattern(foldDecl(cst.ast), location=top.location); }
-| 'ableC_Decl' edu:umn:cs:melt:ableC:concretesyntax:LCurly_t cst::ExternalDeclaration_c edu:umn:cs:melt:ableC:concretesyntax:RCurly_t
+  action { inPattern = false; }
+| 'ableC_Decl' BeginPattern_t '{' cst::ExternalDeclaration_c '}'
   layout {LineComment_t, BlockComment_t, Spaces_t, NewLine_t}
   { forwards to quoteDeclPattern(cst.ast, location=top.location); }
-| 'ableC_Decl' edu:umn:cs:melt:ableC:concretesyntax:LCurly_t ProtoTypedef_c cst::ExternalDeclaration_c edu:umn:cs:melt:ableC:concretesyntax:RCurly_t
+  action { inPattern = false; }
+| 'ableC_Decl' BeginPattern_t '{' ProtoTypedef_c cst::ExternalDeclaration_c '}'
   layout {LineComment_t, BlockComment_t, Spaces_t, NewLine_t}
   { forwards to quoteDeclPattern(cst.ast, location=top.location); }
-| 'ableC_Parameters' edu:umn:cs:melt:ableC:concretesyntax:LCurly_t cst::ParameterList_c edu:umn:cs:melt:ableC:concretesyntax:RCurly_t
+  action { inPattern = false; }
+| 'ableC_Parameters' BeginPattern_t '{' cst::ParameterList_c '}'
   layout {LineComment_t, BlockComment_t, Spaces_t, NewLine_t}
   { forwards to quoteParametersPattern(foldParameterDecl(cst.ast), location=top.location); }
-| 'ableC_BaseTypeExpr' edu:umn:cs:melt:ableC:concretesyntax:LCurly_t cst::DeclarationSpecifiers_c edu:umn:cs:melt:ableC:concretesyntax:RCurly_t
+  action { inPattern = false; }
+| 'ableC_BaseTypeExpr' BeginPattern_t '{' cst::DeclarationSpecifiers_c '}'
   layout {LineComment_t, BlockComment_t, Spaces_t, NewLine_t}
   {
     cst.givenQualifiers = cst.typeQualifiers;
     forwards to quoteBaseTypeExprPattern(figureOutTypeFromSpecifiers(cst.location, cst.typeQualifiers, cst.preTypeSpecifiers, cst.realTypeSpecifiers, cst.mutateTypeSpecifiers), location=top.location);
   }
-| 'ableC_Stmt' edu:umn:cs:melt:ableC:concretesyntax:LCurly_t cst::BlockItemList_c edu:umn:cs:melt:ableC:concretesyntax:RCurly_t
+  action { inPattern = false; }
+| 'ableC_Stmt' BeginPattern_t '{' cst::BlockItemList_c '}'
   layout {LineComment_t, BlockComment_t, Spaces_t, NewLine_t}
   { forwards to quoteStmtPattern(foldStmt(cst.ast), location=top.location); }
-| 'ableC_Expr' edu:umn:cs:melt:ableC:concretesyntax:LCurly_t cst::Expr_c edu:umn:cs:melt:ableC:concretesyntax:RCurly_t
+  action { inPattern = false; }
+| 'ableC_Expr' BeginPattern_t '{' cst::Expr_c '}'
   layout {LineComment_t, BlockComment_t, Spaces_t, NewLine_t}
   { forwards to quoteExprPattern(cst.ast, location=top.location); }
-| 'ableC_Expr' edu:umn:cs:melt:ableC:concretesyntax:LCurly_t ProtoTypedef_c cst::Expr_c edu:umn:cs:melt:ableC:concretesyntax:RCurly_t
+  action { inPattern = false; }
+| 'ableC_Expr' BeginPattern_t '{' ProtoTypedef_c cst::Expr_c '}'
   layout {LineComment_t, BlockComment_t, Spaces_t, NewLine_t}
   { forwards to quoteExprPattern(cst.ast, location=top.location); }
+  action { inPattern = false; }

--- a/grammars/edu.umn.cs.melt.exts.silver.ableC/concretesyntax/quotation/ConcreteSyntax.sv
+++ b/grammars/edu.umn.cs.melt.exts.silver.ableC/concretesyntax/quotation/ConcreteSyntax.sv
@@ -1,6 +1,7 @@
 grammar edu:umn:cs:melt:exts:silver:ableC:concretesyntax:quotation;
 
-imports silver:definition:core hiding LCurly_t, RCurly_t;
+imports silver:definition:core
+  hiding LCurly_t, RCurly_t; -- We only use the ones from ableC, makes '{' terminal syntax unambigous
 imports silver:extension:patternmatching;
 imports edu:umn:cs:melt:exts:silver:ableC:abstractsyntax;
 imports edu:umn:cs:melt:ableC:abstractsyntax:construction;

--- a/grammars/edu.umn.cs.melt.exts.silver.ableC/concretesyntax/quotation/Terminals.sv
+++ b/grammars/edu.umn.cs.melt.exts.silver.ableC/concretesyntax/quotation/Terminals.sv
@@ -6,3 +6,10 @@ marking terminal AbleCParameters_t   'ableC_Parameters'   lexer classes {KEYWORD
 marking terminal AbleCBaseTypeExpr_t 'ableC_BaseTypeExpr' lexer classes {KEYWORD, RESERVED};
 marking terminal AbleCStmt_t         'ableC_Stmt'         lexer classes {KEYWORD, RESERVED};
 marking terminal AbleCExpr_t         'ableC_Expr'         lexer classes {KEYWORD, RESERVED};
+
+-- Expressions do not occur inside patterns, so we only need to track whether we
+-- have seen the beginning (but not the end of) an concrete pattern literal.
+parser attribute inPattern::Boolean
+  action { inPattern = false; };
+
+terminal BeginPattern_t '' action { inPattern = true; };

--- a/grammars/edu.umn.cs.melt.exts.silver.ableC/mda_test/MDA.sv
+++ b/grammars/edu.umn.cs.melt.exts.silver.ableC/mda_test/MDA.sv
@@ -12,4 +12,7 @@ copper_mda testQuote(svParse) {
 copper_mda testAntiquote(ablecParser) {
   edu:umn:cs:melt:exts:silver:ableC:concretesyntax:antiquotation;
   silver:host:core;
+  silver:extension:patternmatching;
+  silver:extension:list;
+  silver:modification:let_fix;
 }


### PR DESCRIPTION
This changes pattern antiquotation to use the same syntax as expression antiquotation.  
This does require parser attributes and a disambiguation class in the implementation, but IMO this is worthwhile as having two different syntaxes for antiqutotation was rather confusing and error-prone.  Now we can write rules like
```
rule on Stmt of
| ableC_Stmt { for ($Decl{init} $Name{i} <= $Expr{limit}; $Expr{iter}) $Stmt{b} } ->
  ableC_Stmt { for ($Decl{init} $Name{i} < $Expr{limit} + 1; $Expr{iter}) $Stmt{b} }
...
end
```
without copy/pasting and forgetting to change some pattern antiquotes into expression ones.

Also this is now another nice example of the features of lexer classes.

See also https://github.com/melt-umn/silver/pull/353