### PR TITLE
Adding project to Jenkins integration

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -134,6 +134,7 @@ melt.trynode('silver-ableC') {
       "ableC-tensor-algebra",
       "ableC-cilk",
       "ableC-tutorials", "ableC-sample-projects",
+      "carbles-ai",
     ]
 
     def tasks = [:]


### PR DESCRIPTION
Adding my AI project that uses ableC to our Jenkins downstream, as this is (currently) our only somewhat large code base using ableC/extensions.  