### PR TITLE
Publishes per-commit artifacts for silver-ableC too.

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -110,6 +110,7 @@ melt.trynode('silver-ableC') {
     // Upon succeeding at initial build, archive for future builds
     dir(SILVER_ABLEC_BASE) {
       archiveArtifacts(artifacts: "jars/*.jar", fingerprint: true)
+      melt.archiveCommitArtifacts("jars/*.jar")
     }
   }
 


### PR DESCRIPTION
This should save melt.nix from having to implement the bootstrapping
logic, and the build time too. No clue if this is sufficient to
implement this though...