### PR TITLE
Avoid running a clean rebuild in bootstrap-compile

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -84,7 +84,7 @@ melt.trynode('silver-ableC') {
     if (!bootstrapRequired) {
       withEnv(newenv) {
         dir(SILVER_ABLEC_BASE) {
-          if (sh(script: './self-compile', returnStatus: true) != 0) {
+          if (sh(script: './self-compile --one-jar', returnStatus: true) != 0) {
             // An error occured, fall back to bootstrapping
             echo "Self-compile build failure, falling back to bootstrap build"
             melt.annotate("Self-compile failure.")
@@ -103,6 +103,8 @@ melt.trynode('silver-ableC') {
       withEnv(newenv) {
         dir(SILVER_ABLEC_BASE) {
           sh './bootstrap-compile'
+          // Perform another clean rebuild to ensure that we have a working fixpoint
+          sh "./self-compile --clean --one-jar"
         }
       }
     }

--- a/bootstrap-compile
+++ b/bootstrap-compile
@@ -26,7 +26,3 @@ mv edu.umn.cs.melt.exts.silver.ableC.composed.with_base.jar ../jars/
 echo "Building Silver + ableC + all extensions with Silver + ableC + base extensions ..."
 silver-custom ../jars/edu.umn.cs.melt.exts.silver.ableC.composed.with_base.jar $INCLUDES $@ edu:umn:cs:melt:exts:silver:ableC:composed:with_all
 mv edu.umn.cs.melt.exts.silver.ableC.composed.with_all.jar ../jars/
-
-echo "Building Silver + ableC + all extensions with Silver + ableC + all extensions ..."
-silver-custom ../jars/edu.umn.cs.melt.exts.silver.ableC.composed.with_all.jar $INCLUDES --one-jar --clean $@ edu:umn:cs:melt:exts:silver:ableC:composed:with_all
-mv edu.umn.cs.melt.exts.silver.ableC.composed.with_all.jar ../jars/


### PR DESCRIPTION
Currently, the `bootstrap-compile` script finishes with a clean rebuild to ensure that the final jar can rebuild itself (since some extensions were built with regular silver or an intermediate version.)  This last step practically never fails and isn't really needed when someone is locally trying to get to a working jar after changing to a  different version of  Silver.  

Instead of always doing this in the `bootstrap-compile` script, we can just run the last clean rebuild step as an extra sanity check on Jenkins.  